### PR TITLE
bug on context unstack + bug on empty synonyms that were triggered

### DIFF
--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
@@ -36,6 +36,8 @@ Also, `util.moment` not available no more. If you used it, alternatives are:
 === Fixed
 
 * browser IDE demo: German is blocked when using Firefox (https://github.com/RosaeNLG/rosaenlg/issues/3)
+* bug on context unstack
+* big bug on empty synonyms: empty alternatives could be triggered when they contained only spaces
 
 === Changed
 

--- a/packages/rosaenlg/src/ChoosebestManager.ts
+++ b/packages/rosaenlg/src/ChoosebestManager.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import { RandomManager } from './RandomManager';
 import { SaveRollbackManager } from './SaveRollbackManager';
 import { SynOptimizer, DebugHolder } from 'synonym-optimizer';

--- a/packages/rosaenlg/src/NlgLib.ts
+++ b/packages/rosaenlg/src/NlgLib.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import { ValueManager } from './ValueManager';
 import { SynManager, SynoMode } from './SynManager';
 import { ChoosebestManager } from './ChoosebestManager';
@@ -62,7 +61,7 @@ export class NlgLib {
 
   private embeddedLinguisticResources: LinguisticResources;
   private spy: Spy;
-  private randomSeed: number;
+  public randomSeed: number; // is read in the output
   private language: Languages;
   private languageImpl: LanguageImpl;
 
@@ -98,7 +97,9 @@ export class NlgLib {
 
     this.genderNumberManager = new GenderNumberManager(this.languageImpl);
     this.helper = new Helper(this.genderNumberManager);
-    this.synManager = new SynManager(this.randomManager, this.saveRollbackManager, params.defaultSynoMode || 'random');
+    this.synManager = new SynManager(this.randomManager, this.saveRollbackManager, {
+      defaultSynoMode: params.defaultSynoMode || 'random',
+    });
     this.verbsManager = new VerbsManager(this.languageImpl, this.genderNumberManager, this.synManager);
 
     this.choosebestManager = new ChoosebestManager(

--- a/packages/rosaenlg/src/ValueManager.ts
+++ b/packages/rosaenlg/src/ValueManager.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import { RefsManager, RepresentantType } from './RefsManager';
 import { RandomManager } from './RandomManager';
 import { AdjectiveManager } from './AdjectiveManager';

--- a/packages/rosaenlg/src/VerbsManager.ts
+++ b/packages/rosaenlg/src/VerbsManager.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import { GenderNumberManager } from './GenderNumberManager';
 import { SynManager } from './SynManager';
 import { LanguageImpl } from './LanguageImpl';

--- a/packages/rosaenlg/test/test-rosaenlg/exceptions.js
+++ b/packages/rosaenlg/test/test-rosaenlg/exceptions.js
@@ -202,6 +202,15 @@ l
 `,
       excepted: 'invalid synonym mode',
     },
+    {
+      name: 'empty synz',
+      template: `
+| start
+synz        
+| end
+`,
+      excepted: 'expected "indent"',
+    },
   ],
   // eslint-disable-next-line @typescript-eslint/naming-convention
   de_DE: [

--- a/packages/rosaenlg/test/test-rosaenlg/synz.js
+++ b/packages/rosaenlg/test/test-rosaenlg/synz.js
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2020 Ludan Stoecklé
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const assert = require('assert');
+const rosaenlg = require('../../dist/index.js');
+
+const templateEmptySyn = `
+| start
+synz
+  syn
+    | syn11
+  syn
+    | syn12
+| middle
+synz
+  syn
+    | syn21
+  syn
+    | syn22
+  syn
+    |
+| end
+`;
+
+const templateAllEmpty = `
+| start
+synz
+  syn
+    |
+  syn
+    if false
+      | should not trigger
+| end
+`;
+
+const templatePathToFind = `
+| start
+synz
+  syn
+    |
+  syn
+    if false
+      | should not trigger
+  syn
+    synz
+      syn
+        |
+      syn
+        if false
+          | should not trigger
+      syn
+        | ok        
+| end
+`;
+
+describe('rosaenlg', function () {
+  it('no empty synonym', function () {
+    for (let j = 0; j < 20; j++) {
+      const params = {
+        language: 'en_US',
+      };
+      const rendered = rosaenlg.render(templateEmptySyn, params);
+
+      assert(rendered.indexOf('syn21') > -1 || rendered.indexOf('syn22') > -1, rendered);
+    }
+  });
+  it('only empty alternatives', function () {
+    const params = {
+      language: 'en_US',
+    };
+    const rendered = rosaenlg.render(templateAllEmpty, params);
+
+    assert.strictEqual(rendered, 'Start end');
+  });
+  it('only 1 good path', function () {
+    const params = {
+      language: 'en_US',
+    };
+    const rendered = rosaenlg.render(templatePathToFind, params);
+
+    assert.strictEqual(rendered, 'Start ok end');
+  });
+});


### PR DESCRIPTION
Signed-off-by: Ludan Stoeckle <ludan.stoeckle@gmail.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [ ] Confirm the PR related to a dedicated issue
- [ ] Confirm your PR corrects a single bug or implements a single feature
- [x] Your code is linted locally prior to submission
- [x] Your code is fully tested: 99% to 100% coverage
- [ ] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [x] Confirm your content is under Apache 2.0 license
- [x] Confirm license and copyright content is created/updated in each file (see CONTRIBUTING.md)
- [x] Confirm `changelog.adoc` is updated

Also remember: each commit **MUST** contain a sign off message (see CONTRIBUTING.md) 🙄

## Indicate related issue: 

no opened issue

## Explain what is done, scope, limitations etc.

- bug on context unstack
- big bug on empty synonyms: empty alternatives could be triggered when they contained only spaces


## Does this PR introduce a breaking change? 😁

no