### PR TITLE
wrong gh pages link

### DIFF
--- a/packages/rosaenlg-doc-website/playbook-gh-pages.yml
+++ b/packages/rosaenlg-doc-website/playbook-gh-pages.yml
@@ -1,7 +1,7 @@
 site:
   title: RosaeNLG // Docs
   # the 404 page and sitemap files only get generated when the url property is set
-  url: https://rosaenlg.github.io/docs-site
+  url: https://rosaenlg.github.io/rosaenlg
   start_page: rosaenlg:ROOT:index.adoc
 content:
   sources:

--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/index.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ p
 
 == About the documentation
 
-The main documentation site is link:https://rosaenlg.org[rosaenlg.org]. A mirror is available on link:https://rosaenlg.github.io/docs-site[Github pages], but without the search bar.
+The main documentation site is link:https://rosaenlg.org[rosaenlg.org]. A mirror is available on link:https://rosaenlg.github.io/rosaenlg[Github pages], but without the search bar.
 
 
 == Logo


### PR DESCRIPTION
Signed-off-by: Ludan Stoeckle <ludan.stoeckle@gmail.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [ ] Confirm the PR related to a dedicated issue
- [x] Confirm your PR corrects a single bug or implements a single feature
- [x] Your code is linted locally prior to submission
- [x] Your code is fully tested: 99% to 100% coverage
- [x] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [x] Confirm your content is under Apache 2.0 license
- [x] Confirm license and copyright content is created/updated in each file (see CONTRIBUTING.md)
- [ ] Confirm `changelog.adoc` is updated
- [ ] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see CONTRIBUTING.md) 🙄

## Explain what is done, scope, limitations etc.

gh pages URL was wrong, both in antora playbook and in doc

## Does this PR introduce a breaking change? 😁

no