### PR TITLE
&attributes pug feature and pug-parser

### DIFF
--- a/packages/rosaenlg-pug-parser/index.js
+++ b/packages/rosaenlg-pug-parser/index.js
@@ -1340,7 +1340,7 @@ Parser.prototype = {
       switch (this.peek().type) {
         case 'id':
         case 'class':
-          let tok = this.advance();
+          var tok = this.advance();
           if (tok.type === 'id') {
             if (attributeNames.indexOf('id') !== -1) {
               this.error('DUPLICATE_ID', 'Duplicate attribute "id" is not allowed.', tok);
@@ -1369,7 +1369,7 @@ Parser.prototype = {
           tag.attrs = tag.attrs.concat(this.attrs(attributeNames));
           continue;
         case '&attributes':
-          tok = this.advance();
+          var tok = this.advance();
           tag.attributeBlocks.push({
             type: 'AttributeBlock',
             val: tok.val,


### PR DESCRIPTION
tok var definition fix in tag function

Signed-off-by: Winckel Mathias <mathias.winckel@addventa.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [ ] Confirm the PR related to a dedicated issue
- [ ] Confirm your PR corrects a single bug or implements a single feature
- [ ] Your code is linted locally prior to submission
- [ ] Your code is fully tested: 99% to 100% coverage
- [ ] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [ ] Confirm your code is under Apache 2.0 license
- [ ] Confirm your documentation is under CC-BY-4.0 license
- [ ] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [ ] Confirm `changelog.adoc` is updated
- [ ] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

None

## Explain what is done, scope, limitations etc.

When using pug's `&attributes` feature, for tag attributes, the pug parser may crash trying to affect a variable
`Exception has occurred: ReferenceError: Cannot access 'tok' before initialization`

a basic example
```
whatever()&attributes({ test: "crash" })
    | something
```
should trigger it

A `tok` variable is simply not properly defined in the `tag` method of the `Parser` class

_appeal to authority argumentation:_ official pug parser repository had this correction

## Does this PR introduce a breaking change? 😁

No