### PR TITLE
fix rosaenlg AsmManager.ts

### DIFF
--- a/packages/rosaenlg/src/AsmManager.ts
+++ b/packages/rosaenlg/src/AsmManager.ts
@@ -335,7 +335,7 @@ export class AsmManager {
   }
 
   private listStuffSentences(which: MixinFct, nonEmpty: any[], asm: Asm, params: any): void {
-    if (asm.end != null && !this.isMixin(asm.end) && this.isDot(asm.end as string)) {
+    if (asm.mode === 'paragraph' && asm.end != null && !this.isMixin(asm.end) && this.isDot(asm.end as string)) {
       const err = new Error();
       err.name = 'InvalidArgumentError';
       err.message = `when assemble mode is paragraph, the end is ignored when it is a dot.`;

--- a/packages/rosaenlg/src/AsmManager.ts
+++ b/packages/rosaenlg/src/AsmManager.ts
@@ -335,7 +335,7 @@ export class AsmManager {
   }
 
   private listStuffSentences(which: MixinFct, nonEmpty: any[], asm: Asm, params: any): void {
-    if (asm.mode === 'paragraph' && asm.end != null && !this.isMixin(asm.end) && this.isDot(asm.end as string)) {
+    if (asm.mode === 'paragraphs' && asm.end != null && !this.isMixin(asm.end) && this.isDot(asm.end as string)) {
       const err = new Error();
       err.name = 'InvalidArgumentError';
       err.message = `when assemble mode is paragraph, the end is ignored when it is a dot.`;


### PR DESCRIPTION
checking asm mode for 'paragraph' before throwing a paragraph error

Signed-off-by: Winckel Mathias <mathias.winckel@addventa.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [ ] Confirm the PR related to a dedicated issue
- [ ] Confirm your PR corrects a single bug or implements a single feature
- [ ] Your code is linted locally prior to submission
- [ ] Your code is fully tested: 99% to 100% coverage
- [ ] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [ ] Confirm your code is under Apache 2.0 license
- [ ] Confirm your documentation is under CC-BY-4.0 license
- [ ] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [ ] Confirm `changelog.adoc` is updated
- [ ] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

None

## Explain what is done, scope, limitations etc.

When using the `"list"` mode in an assembly with its `end` set to a `"."`, AsmManager's `listStuffSentences` method throws a paragraph mode related error:
`when assemble mode is paragraph, the end is ignored when it is a dot.`
It doesn't check the asm mode value before throwing it.

It may be weird to use a single . for ending a bullet points listing.
But, as the error message is written, checking the asm mode value for `paragraph` seems the right thing to do.

## Does this PR introduce a breaking change? 😁

None
