### PR TITLE
correction of interpolated tag name without space

### DIFF
--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
@@ -10,7 +10,7 @@ https://keepachangelog.com/en/0.3.0/
 
 
 === Fixed
-
+* bug \#97: inconvenient spaces in tag name interpolation and attributes
 
 === Changed
 

--- a/packages/rosaenlg-filter/lib/html.ts
+++ b/packages/rosaenlg-filter/lib/html.ts
@@ -33,6 +33,8 @@ export const blockLevelElts = [
   'h5',
   'h6',
   'header',
+  'head',
+  'body',
   'hr',
   'li',
   'main',

--- a/packages/rosaenlg-pug-code-gen/lib/index.js
+++ b/packages/rosaenlg-pug-code-gen/lib/index.js
@@ -319,7 +319,7 @@ Compiler.prototype = {
    * @api public
    */
 
-  bufferExpression: function (src) {
+  bufferExpression: function (src, addSpaces=true) {
     if (isConstant(src)) {
       return this.buffer(toConstant(src) + '');
     }
@@ -327,7 +327,9 @@ Compiler.prototype = {
       this.bufferedConcatenationCount++;
       if (this.lastBufferedType === 'text') this.lastBuffered += '"';
       this.lastBufferedType = 'code';
-      this.lastBuffered += ' + "¤" + (' + src + ') + "¤"';
+      if(addSpaces) this.lastBuffered += ' + "¤"'; 
+      this.lastBuffered += ' + (' + src + ')';
+      if(addSpaces) this.lastBuffered += ' + "¤"';
       this.buf[this.lastBufferedIdx - 1] = 'pug_html = pug_html + (' + this.bufferStartChar + this.lastBuffered + ');';
     } else {
       this.bufferedConcatenationCount = 0;
@@ -793,7 +795,7 @@ Compiler.prototype = {
       self = this;
 
     function bufferName() {
-      if (interpolated) self.bufferExpression(tag.expr);
+      if (interpolated) self.bufferExpression(tag.expr, false);
       else self.buffer(name);
     }
 
@@ -1166,9 +1168,10 @@ Compiler.prototype = {
             ']), ' +
             stringify(this.terse) +
             ')',
+            false
         );
       } else {
-        this.bufferExpression(this.runtime('attrs') + '(' + attributeBlocks[0] + ', ' + stringify(this.terse) + ')');
+        this.bufferExpression(this.runtime('attrs') + '(' + attributeBlocks[0] + ', ' + stringify(this.terse) + ')', false);
       }
     } else if (attrs.length) {
       this.attrs(attrs, true);

--- a/packages/rosaenlg/test/test-rosaenlg/withStructure.js
+++ b/packages/rosaenlg/test/test-rosaenlg/withStructure.js
@@ -23,6 +23,10 @@ p
     | !
 `;
 
+const templateInterpolatedTagName = `- var tagName = "p"
+#{tagName}(attr="value") test
+`;
+
 describe('rosaenlg', function () {
   describe('quickstart', function () {
     const rendered = rosaenlgPug.render(templateQuickStart, {
@@ -41,6 +45,15 @@ describe('rosaenlg', function () {
 
     it('test with p', function () {
       assert.strictEqual(rendered, '<p>This is a sentence. <p>And yes, this is another sentence!</p></p>');
+    });
+  });
+  describe('interpolated tag name', function () {
+    const rendered = rosaenlgPug.render(templateInterpolatedTagName, {
+      language: 'en_US',
+    });
+
+    it('test no space in tag when using an interpolated tag name', function () {
+      assert.strictEqual(rendered, '<p attr="value">Test</p>');
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: Winckel Mathias <mathias.winckel@addventa.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [X] Confirm the PR related to a dedicated issue
- [X] Confirm your PR corrects a single bug or implements a single feature
- [X] Your code is linted locally prior to submission
- [X] Your code is fully tested: 99% to 100% coverage
- [X] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [X] Confirm your code is under Apache 2.0 license
- [X] Confirm your documentation is under CC-BY-4.0 license
- [X] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [x] Confirm `changelog.adoc` is updated
- [ ] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

issue #97

## Explain what is done, scope, limitations etc.
Adds a `addSpaces=true` parameter in the `bufferExpression` method in the index.js file of the rosaenlg-pug-code-gen package.
This parameter is used to avoid adding the `¤` space symbol in the generated code, and is set to false when evaluating an interpolation or attributes.

## Does this PR introduce a breaking change? 😁

