### PR TITLE
fix regex matching eachz ... with ... to avoid matching it in an asse…

### DIFF
--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
@@ -11,6 +11,7 @@ https://keepachangelog.com/en/0.3.0/
 
 === Fixed
 
+* ` with ` keyword for an assembly in `eachz` no longer matching if it appears as text in the assembly
 
 === Changed
 

--- a/packages/rosaenlg-pug-lexer/index.js
+++ b/packages/rosaenlg-pug-lexer/index.js
@@ -1150,7 +1150,8 @@ Lexer.prototype = {
 
   eachz: function () {
     //console.log('LEXER eachz');
-    let captures = /^eachz +([a-zA-Z_$][\w$]*) in ([^\n]+) with ([^\n]+)/.exec(this.input);
+    // the lazy +? is required for not matching the with keyword in the assembly
+    let captures = /^eachz +([a-zA-Z_$][\w$]*) in ([^\n]+?) with ([^\n]+)/.exec(this.input);
     if (!captures) {
       // same without "with"
       captures = /^eachz +([a-zA-Z_$][\w$]*) in ([^\n]+)/.exec(this.input);

--- a/packages/rosaenlg/test/test-rosaenlg/en_US/foreach.pug
+++ b/packages/rosaenlg/test/test-rosaenlg/en_US/foreach.pug
@@ -14,8 +14,10 @@
     test B X var and B Y var and test C X var and C Y var
     C B Z
     A B
+    first and second
+    first using with before second
+    first using with separating second
   `;
-
 
 - var elts = ['A','B','C','D'];
 
@@ -66,3 +68,15 @@ t
   l
     eachz val in ['A', 'B']
       | #{val}
+
+  l
+    eachz _word in ["first", "second"] with { separator: "and" }
+      | #{_word}
+  l
+    eachz _word in ["first", "second"] with { separator: "using with before" }
+      | #{_word}
+
+  l
+    - const withList = ["first", "second"]
+    eachz _word in withList with { separator: "using with separating" }
+      | #{_word}


### PR DESCRIPTION

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [X] Confirm the PR related to a dedicated issue
- [X] Confirm your PR corrects a single bug or implements a single feature
- [X] Your code is linted locally prior to submission
- [X] Your code is fully tested: 99% to 100% coverage
- [X] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [X] Confirm your code is under Apache 2.0 license
- [X] Confirm your documentation is under CC-BY-4.0 license
- [X] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [X] Confirm `changelog.adoc` is updated
- [X] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

issue #116 

## Explain what is done, scope, limitations etc.

avoid matching the ` with ` keyword of eachz in the content of the assembly itself

## Does this PR introduce a breaking change? 😁

you can't no longer have " with " in a string directly in the list of an eachz...
