### PR TITLE
allows matching 0 space before or after EATSPACE

### DIFF
--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
@@ -11,6 +11,8 @@ https://keepachangelog.com/en/0.3.0/
 
 === Fixed
 
+* eatSpace symbol can now work without space before or after
+
 === Changed
 
 ////

--- a/packages/rosaenlg-filter/lib/punctuation.ts
+++ b/packages/rosaenlg-filter/lib/punctuation.ts
@@ -61,7 +61,7 @@ export function cleanSpacesPunctuation(input: string, languageFilter: LanguageFi
   res = res.trim();
 
   // eat spaces
-  const eatspaceRe = new RegExp(`[\\s¤]+${EATSPACE}[\\s¤]+`, 'g');
+  const eatspaceRe = new RegExp(`[\\s¤]*${EATSPACE}[\\s¤]*`, 'g');
   res = res.replace(eatspaceRe, '');
 
   res = languageFilter.cleanSpacesPunctuationCorrect(res);

--- a/packages/rosaenlg/test/test-rosaenlg/en_US/misc.pug
+++ b/packages/rosaenlg/test/test-rosaenlg/en_US/misc.pug
@@ -5,6 +5,8 @@
     Bla…
     bxlabla
     bylabla
+    rbla
+    lbla
     Some Uppercase
 
     singular
@@ -15,6 +17,8 @@
 t
   l bla #{'\u2026'}
   l bxla #[+eatSpace()] bla
+  l #[+eatSpace()] rbla
+  l lbla #[+eatSpace()]
   l byla
     | #[+eatSpace()]
     | bla


### PR DESCRIPTION
Signed-off-by: Winckel Mathias <mathias.winckel@addventa.com>

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [X] Confirm the PR related to a dedicated issue
- [X] Confirm your PR corrects a single bug or implements a single feature
- [X] Your code is linted locally prior to submission
- [X] Your code is fully tested: 99% to 100% coverage
- [X] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_RosaeNLG)
- [X] Confirm your code is under Apache 2.0 license
- [X] Confirm your documentation is under CC-BY-4.0 license
- [X] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [X] Confirm `changelog.adoc` is updated
- [X] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

issue #119 

## Explain what is done, scope, limitations etc.
Seems that whitespaces around EATSPACE place holder could be removed by other punctuation rules.
EATSPACE regex matching no longer requires whitespaces to work ( `[\\s¤]+ => [\\s¤]*`)
It avoids any chance of a EATSPACE text appearing after rendering.

## Does this PR introduce a breaking change? 😁
no
