### PR TITLE
Add missing Spanish irregular verbs (subjuntivo exceptions)

### DIFF
--- a/packages/spanish-verbs/src/exceptions.ts
+++ b/packages/spanish-verbs/src/exceptions.ts
@@ -1153,6 +1153,8 @@ export const exceptions: Exceptions = {
           third: 'siga',
         },
         plural: {
+          first: 'sigamos',
+          second: 'sigáis',
           third: 'sigan',
         },
       },
@@ -1901,6 +1903,98 @@ export const exceptions: Exceptions = {
         plural: {
           second: 'vengáis',
           third: 'vengan',
+        },
+      },
+    },
+  },
+  corregir: {
+    subjunctive: {
+      present: {
+        singular: {
+          first: 'corrija',
+          second: 'corrijas',
+          third: 'corrija',
+        },
+        plural: {
+          first: 'corrijamos',
+          second: 'corrijáis',
+          third: 'corrijan',
+        },
+      },
+    },
+  },
+  construir: {
+    subjunctive: {
+      present: {
+        singular: {
+          first: 'construya',
+          second: 'construyas',
+          third: 'construya',
+        },
+        plural: {
+          first: 'construyamos',
+          second: 'construyáis',
+          third: 'construyan',
+        },
+      },
+    },
+  },
+  mantener: {
+    indicative: {
+      present: {
+        singular: {
+          first: 'mantengo',
+          second: 'mantienes',
+          third: 'mantiene',
+        },
+        plural: {
+          first: 'mantenemos',
+          second: 'mantenéis',
+          third: 'mantienen',
+        },
+      }
+    },
+    subjunctive: {
+      present: {
+        singular: {
+          first: 'mantenga',
+          second: 'mantengas',
+          third: 'mantenga',
+        },
+        plural: {
+          first: 'mantengamos',
+          second: 'mantengáis',
+          third: 'mantengan',
+        },
+      },
+    },
+  },
+  huir: {
+    indicative: {
+      present: {
+        singular: {
+          first: 'huyo',
+          second: 'huyes',
+          third: 'huye',
+        },
+        plural: {
+          first: 'huimos',
+          second: 'huís',
+          third: 'huyen',
+        },
+      }
+    },
+    subjunctive: {
+      present: {
+        singular: {
+          first: 'huya',
+          second: 'huyas',
+          third: 'huya',
+        },
+        plural: {
+          first: 'huyamos',
+          second: 'huyáis',
+          third: 'huyan',
         },
       },
     },


### PR DESCRIPTION
**Summary**
This PR adds several missing irregular Spanish verbs used in subjuntivo conjugations.
These verbs currently produce incorrect conjugation results, since they do not appear in the internal exception tables.

The following verbs have been added: seguir, corregir, construir, mantener, huir

More irregular verbs will be added in future incremental PRs to keep the scope focused and easy to review.

**Scope and motivation**

These verbs behave irregularly in subjuntivo (e.g., siga, corrija, construya, mantenga, huya), but the library treated them as regular ones.
This PR updates the Spanish conjugation dictionary so that RosaeNLG produces correct morphological forms in generated texts.

The change is backward-compatible and does not introduce breaking changes.

**Related issue**

No issue was created because the change is small and self-contained.
If needed, I can open an issue and link it.